### PR TITLE
공통 응답객체를 제대로 사용하지 않아 오류 발견으로 인해 수정 함.

### DIFF
--- a/src/main/java/com/concert/ticketing/domain/member/controller/AuthController.java
+++ b/src/main/java/com/concert/ticketing/domain/member/controller/AuthController.java
@@ -31,8 +31,7 @@ public class AuthController {
     ) {
         authService.signup(request);
 
-        ApiResponse<Void> response = new ApiResponse<>(
-                true,
+        ApiResponse<Void> response = ApiResponse.success(
                 "회원가입 성공",
                 null
         );
@@ -48,8 +47,7 @@ public class AuthController {
         String token = authService.login(request);
         LoginResponseDto responseDto = new LoginResponseDto(token);
 
-        ApiResponse<LoginResponseDto> response = new ApiResponse<>(
-                true,
+        ApiResponse<LoginResponseDto> response = ApiResponse.success(
                 "로그인 성공",
                 responseDto
         );

--- a/src/main/java/com/concert/ticketing/domain/member/service/AuthService.java
+++ b/src/main/java/com/concert/ticketing/domain/member/service/AuthService.java
@@ -23,10 +23,11 @@ public class AuthService {
             throw new IllegalArgumentException("이미 가입된 이메일입니다.");
         }
 
-        Member member = new Member();
-        member.setEmail(request.getEmail());
-        member.setPassword(passwordEncoder.encode(request.getPassword()));
-        member.setName(request.getName());
+        Member member = new Member(
+                request.getEmail(),
+                passwordEncoder.encode(request.getPassword()),
+                request.getName()
+        );
 
         memberRepository.save(member);
     }


### PR DESCRIPTION
## 상세 내용
오류 내용 수정
-  AuthController
로그인과 회원가입에 ApiResponse의 형식에 맞게 수정 함.
- AuthService
회원가입에 set를 사용할 필요가 없는데 사용하고 있어서 그 부분을 수정 함

## 주의 사항
기존 ApiResponse, 맴버Entity을 사용하고,  제가 수정한 것은 쓰지 않는 것은 사용하지 않는 것으로 해야됌.